### PR TITLE
updated similar_songs_index part of predictor function

### DIFF
--- a/model.py
+++ b/model.py
@@ -56,7 +56,10 @@ def knn_predictor(audio_feats):
   prediction = nn.kneighbors(audio_feats_scaled)
 
   # Get the indexes of the list of similar songs
-  similar_songs_index = prediction[1][0][1:].tolist()
+  if prediction[0][0][0] == 0.0:
+    similar_songs_index = prediction[1][0][1:].tolist()
+  else:
+    similar_songs_index = prediction[1][0][:5].tolist()
   
   # Create an empty list to store simlar song names
   similar_song_ids = []


### PR DESCRIPTION
Initially, I had the KNN set up where it would automatically dismiss the first neighbor in the prediction just in case the input song was in the database. This would prevent the predictor from returning the input song as a recommendation. Now it's set up to where if the input song is in the database, it returns the last 5 neighbors (out of 6) and if it's not in the database, it returns the first 5 neighbors. 